### PR TITLE
feat: add textproto as a language [GT-8444]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withgraphite/language-services",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "license": "None",
   "description": "A mapping of file extensions to languages",
   "main": "dist/src/index.js",

--- a/src/ext.ts
+++ b/src/ext.ts
@@ -775,7 +775,7 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
     vbhtml: "basic",
     vbs: "basic",
     volt: "txt",
-    vue: "txt",
+    vue: "Vue",
     owl: "txt",
     webidl: "txt",
     x10: "txt",

--- a/src/ext.ts
+++ b/src/ext.ts
@@ -906,6 +906,9 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
     prg: "txt",
     prw: "txt",
     svelte: "svelte",
+    textproto: "textproto",
+    pbtxt: "textproto",
+    prototxt: "textproto",
   };
 
   export function languageFromExtension(extension: string) {

--- a/src/highlight.ts
+++ b/src/highlight.ts
@@ -6,12 +6,14 @@ terraform(hljs);
 svelte(hljs);
 // Add additional `hljs` configuration here
 
+const VSCODE_SYNTAX_HIGHLIGHTING_LANGUAGES = ["textproto", "Vue"];
+
 export function highlight(language: string, code: string) {
   return hljs.highlight(code, { language });
 }
 
 export function supportsLanguage(language: string) {
-  return typeof hljs.getLanguage(language) !== "undefined";
+  return VSCODE_SYNTAX_HIGHLIGHTING_LANGUAGES.includes(language) || typeof hljs.getLanguage(language) !== "undefined";
 }
 
 export function getFullLanguageName(languageName: string) {
@@ -29,5 +31,10 @@ export function listLanguages() {
       language: language,
       name: hljs.getLanguage(language)?.name || language,
     };
-  });
+  }).concat(VSCODE_SYNTAX_HIGHLIGHTING_LANGUAGES.map((language) => {
+    return {
+      language: language,
+      name: language,
+      };
+  }));
 }


### PR DESCRIPTION
Also adds languages we support via VSCode syntax highlighting as supported languages, which fixes a bug where we would treat these files as plaintext and skip highlighting.