### PR TITLE
feat: mark godot files as having VSCode support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@withgraphite/language-services",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "license": "None",
   "description": "A mapping of file extensions to languages",
   "main": "dist/src/index.js",

--- a/src/ext.ts
+++ b/src/ext.ts
@@ -909,6 +909,14 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
     textproto: "textproto",
     pbtxt: "textproto",
     prototxt: "textproto",
+    gdscript: "gdscript",
+    gdshader: "gdshader",
+    godot: "gdresource",
+    tres: "gdresource",
+    tscn: "gdresource",
+    import: "gdresource",
+    gdns: "gdresource",
+    gdnlib: "gdresource",
   };
 
   export function languageFromExtension(extension: string) {

--- a/src/highlight.ts
+++ b/src/highlight.ts
@@ -6,7 +6,7 @@ terraform(hljs);
 svelte(hljs);
 // Add additional `hljs` configuration here
 
-const VSCODE_SYNTAX_HIGHLIGHTING_LANGUAGES = ["textproto", "Vue"];
+const VSCODE_SYNTAX_HIGHLIGHTING_LANGUAGES = ["textproto", "Vue", "gdscript", "gdshader", "gdresource"];
 
 export function highlight(language: string, code: string) {
   return hljs.highlight(code, { language });
@@ -35,6 +35,6 @@ export function listLanguages() {
     return {
       language: language,
       name: language,
-      };
+    };
   }));
 }


### PR DESCRIPTION
Our engine already supports godot files, we just need to explicitly mark them as supported :) 
